### PR TITLE
Handle bad cropping size in `hsfm.core.preprocess_image`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Example files
+examples/input_data/**
+examples/qc/**

--- a/hsfm/batch/batch.py
+++ b/hsfm/batch/batch.py
@@ -511,13 +511,22 @@ def run_metashape(project_name,
     
 
     ba_CE90, ba_LE90 = hsfm.geospatial.CE90(x_offset,y_offset), hsfm.geospatial.LE90(z_offset)
-    hsfm.plot.plot_offsets(ba_LE90,
-                           ba_CE90,
-                           x_offset, 
-                           y_offset, 
-                           z_offset,
-                           title = 'Initial vs Bundle Adjusted',
-                           plot_file_name = os.path.join(output_path, 'qc_ba_ce90le90.png'))
+    
+    #This might help to stop errors from being thrown in the case of a bad (?) image
+    if np.isfinite(x_offset).all() & np.isfinite(y_offset).all() & np.isfinite(z_offset).all():
+        hsfm.plot.plot_offsets(ba_LE90,
+                                ba_CE90,
+                                x_offset,
+                                y_offset,
+                                z_offset,
+                                title = 'Initial vs Bundle Adjusted',
+                                plot_file_name = os.path.join(output_path, 'qc_ba_ce90le90.png'))
+    else:
+        print("Cannot plot offsets because x, y, and/or z offset is non finite:")
+        print(f"x offset: {x_offset}")
+        print(f"y offset: {y_offset}")
+        print(f"z offset: {z_offset}")
+
     
     if ba_CE90 < 0.01 and ba_LE90 < 0.01:
         if generate_ortho:

--- a/hsfm/batch/batch.py
+++ b/hsfm/batch/batch.py
@@ -378,7 +378,7 @@ def preprocess_images(template_directory,
                                                             invisible_fiducial=invisible_fiducial,
                                                             crop_from_pp_dist=crop_from_pp_dist,
                                                             manually_pick_fiducials=manually_pick_fiducials,
-                                                            side = side
+                                                            side = side,
                                                             angle_threshold=angle_threshold)
             intersections.append(intersection_angle)
             file_names.append(file_name)

--- a/hsfm/batch/batch.py
+++ b/hsfm/batch/batch.py
@@ -341,7 +341,8 @@ def preprocess_images(template_directory,
                       invisible_fiducial=None,
                       crop_from_pp_dist = 11250,
                       manually_pick_fiducials=False,
-                      side = None):
+                      side = None,
+                      angle_threshold = 0.2):
                       
     """
     Function to preprocess images from NAGAP archive in batch.
@@ -377,7 +378,8 @@ def preprocess_images(template_directory,
                                                             invisible_fiducial=invisible_fiducial,
                                                             crop_from_pp_dist=crop_from_pp_dist,
                                                             manually_pick_fiducials=manually_pick_fiducials,
-                                                            side = side)
+                                                            side = side
+                                                            angle_threshold=angle_threshold)
             intersections.append(intersection_angle)
             file_names.append(file_name)
     

--- a/hsfm/core/core.py
+++ b/hsfm/core/core.py
@@ -943,23 +943,10 @@ def crop_about_principal_point(grayscale_unit8_image_array,
     size_xdim = len(img_gray[0])
     size_ydim = len(img_gray)
 
-    print(size_xdim)
-    print(size_ydim)
-    print()
-
     x_L = int(principal_point[0]-crop_from_pp_dist/2)
     x_R = int(principal_point[0]+crop_from_pp_dist/2)
-
-    print(x_L)
-    print(x_R)
-    print()
-
     y_T = int(principal_point[1]-crop_from_pp_dist/2)
     y_B = int(principal_point[1]+crop_from_pp_dist/2)
-    
-    print(y_T)
-    print(y_B)
-    print()
 
     new_crop_dist_for_x = crop_from_pp_dist
     new_crop_dist_for_y = crop_from_pp_dist

--- a/hsfm/core/core.py
+++ b/hsfm/core/core.py
@@ -967,10 +967,6 @@ def crop_about_principal_point(grayscale_unit8_image_array,
     cropped = hsfm.image.clahe_equalize_image(cropped)
     cropped = hsfm.image.img_linear_stretch(cropped)
 
-    print('FINAL DIMENSIONS:')
-    print(len(cropped))
-    print(len(cropped[0]))
-    print()
     return cropped
     
 def move_match_files_in_sequence(bundle_adjust_directory,


### PR DESCRIPTION
1. Changes to `hsfm.core.crop_about_principal_point` such that a call to `hsfm.core.preprocess_image` will fail if it cannot produce a square image. A log message recommends a proper crop size. This may happen if an image was scanned poorly, a fiducial marker is missing, and as a result the principal/optical point is far from the center of the image as defined by pixels. Note that right now, the recommended proper crop size may be a non-integer (ie 10759.5). I think in that case one should round down (to 10759).

2. Change `hsfm.core.detect_fiducials` to allow the parameter `invisible_fiducial` to equal `top` in addition to `right`.

3. Angle threshold parameter extended from core.preprocess_image to batch.preprocess_images.

4. Changes to the QC step of `hsfm.batch.preprocess_images` to avoid failure when trying to plot non-existent offsets. Not sure when this is useful...maybe we should wait on merging that change.



Note: I tested the new code by processing the following NAGAP images:
> NAGAP_92V5_268
> NAGAP_92V5_269
> NAGAP_92V5_270
> NAGAP_92V5_271
> NAGAP_92V5_272
> NAGAP_92V5_273